### PR TITLE
fix: 修复中文翻译中的人数单位

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -149,7 +149,7 @@ fetchJsonp('https://interface.sina.cn/news/wap/fymap2020_data.d.json')
                     properties: {
                         title: "Infection Density",
                         abbv: "密度 Density",
-                        desc: "Infections per 10,000 km² / 每 km² 感染数",
+                        desc: "Infections per 10,000 km² / 每 10,000 km² 感染数",
                         toFixed: 4
                     }
                 },


### PR DESCRIPTION
"Infections per 10,000 km²" 对应的中文翻译应该为 “每 10,000 km² 感染数”

![image](https://user-images.githubusercontent.com/25521218/73507690-baaa9e80-4414-11ea-801c-f2672d8898b2.png)
